### PR TITLE
Hashlookup returns the mod version associated with the hash

### DIFF
--- a/src/api/routes/getMod.ts
+++ b/src/api/routes/getMod.ts
@@ -172,15 +172,22 @@ export class GetModRoutes {
                 return res.status(400).send({ message: `Missing hash.` });
             }
 
+            // i'm dont have a type for the raw mod version
+            let retVal: any[] = [];
+
             for (const version of DatabaseHelper.cache.modVersions) {
                 if (version.zipHash === hash) {
-                    return res.status(200).send({ modVersion: await (raw ? version.toRawAPIResonse() : version.toAPIResonse()) });
+                    retVal.push(await (raw ? version.toRawAPIResonse() : version.toAPIResonse()));
                 }
                 for (const fileHash of version.contentHashes) {
                     if (fileHash.hash === hash) {
-                        return res.status(200).send({ modVersion: await (raw ? version.toRawAPIResonse() : version.toAPIResonse()) });
+                        retVal.push(await (raw ? version.toRawAPIResonse() : version.toAPIResonse()));
                     }
                 }
+            }
+
+            if (retVal.length > 0) {
+                return res.status(200).send({ modVersions: retVal });
             }
             return res.status(404).send({ message: `Hash not found.` });
         });

--- a/src/api/routes/getMod.ts
+++ b/src/api/routes/getMod.ts
@@ -157,24 +157,28 @@ export class GetModRoutes {
 
         this.app.get(`/api/hashlookup`, async (req, res) => {
             // #swagger.tags = ['Mods']
-            // #swagger.summary = 'Show a mod that has a file with the specified hash.'
-            // #swagger.description = 'Show a mod that has a file with the specified hash. This is useful for finding the mod that a file belongs to.'
-            // #swagger.responses[200] = { description: 'Returns the mod.' }
+            // #swagger.summary = 'Get a specific mod version that has a file with the specified hash.'
+            // #swagger.description = 'Get a specific mod version that has a file with the specified hash. This is useful for finding the mod that a file belongs to.'
+            // #swagger.responses[200] = { description: 'Returns the mod version.' }
             // #swagger.responses[400] = { description: 'Missing hash.' }
             // #swagger.responses[404] = { description: 'Hash not found.' }
             // #swagger.parameters['hash'] = { description: 'The hash to look up.', type: 'string', required: true }
-            let hash = Validator.zString.min(8).safeParse(req.query.hash);
+            // #swagger.parameters['raw'] = { description: 'Return the raw mod depedendcies without attempting to resolve them.', type: 'boolean' }
+
+            const hash = Validator.zString.min(8).safeParse(req.query.hash).data;
+            const raw = Validator.zBool.safeParse(req.query.raw).data;
+
             if (!hash) {
                 return res.status(400).send({ message: `Missing hash.` });
             }
 
-            for (let version of DatabaseHelper.cache.modVersions) {
-                if (version.zipHash === hash.data) {
-                    return res.status(200).send({ mod: version.modId });
+            for (const version of DatabaseHelper.cache.modVersions) {
+                if (version.zipHash === hash) {
+                    return res.status(200).send({ modVersion: await (raw ? version.toRawAPIResonse() : version.toAPIResonse()) });
                 }
-                for (let fileHash of version.contentHashes) {
-                    if (fileHash.hash === hash.data) {
-                        return res.status(200).send({ mod: version.modId });
+                for (const fileHash of version.contentHashes) {
+                    if (fileHash.hash === hash) {
+                        return res.status(200).send({ modVersion: await (raw ? version.toRawAPIResonse() : version.toAPIResonse()) });
                     }
                 }
             }

--- a/src/api/swagger.json
+++ b/src/api/swagger.json
@@ -341,8 +341,8 @@
         "tags": [
           "Mods"
         ],
-        "summary": "Show a mod that has a file with the specified hash.",
-        "description": "Show a mod that has a file with the specified hash. This is useful for finding the mod that a file belongs to.",
+        "summary": "Get a specific mod version that has a file with the specified hash.",
+        "description": "Get a specific mod version that has a file with the specified hash. This is useful for finding the mod that a file belongs to.",
         "parameters": [
           {
             "name": "hash",
@@ -350,11 +350,17 @@
             "type": "string",
             "required": true,
             "in": "query"
+          },
+          {
+            "name": "raw",
+            "description": "Return the raw mod depedendcies without attempting to resolve them.",
+            "type": "boolean",
+            "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Returns the mod."
+            "description": "Returns the mod version."
           },
           "400": {
             "description": "Missing hash."


### PR DESCRIPTION
I believe the main purpose of this route is to retrieve the mod version using the hash

By returning only the mod ID, we need to make a second request to get the mod details. Moreover, getting the mod by its id includes all versions of the mod, resulting in a lot of unnecessary data being sent when we only want the mod version associated with the hash