### PR TITLE
Increase upload limit + prevent uploading to removed mods

### DIFF
--- a/src/api/routes/approval.ts
+++ b/src/api/routes/approval.ts
@@ -636,6 +636,7 @@ export class ApprovalRoutes {
                         category: reqBodym.data.category || edit.object.category,
                         authorIds: reqBodym.data.authorIds || edit.object.authorIds,
                         gameName: reqBodym.data.gameName || edit.object.gameName,
+                        fileSize: mod.fileSize || edit.object.fileSize
                     };
                     edit.save();
                     break;
@@ -669,6 +670,7 @@ export class ApprovalRoutes {
                         supportedGameVersionIds: reqBodyv.data.supportedGameVersionIds || edit.object.supportedGameVersionIds,
                         dependencies: reqBodyv.data.dependencies || edit.object.dependencies,
                         platform: reqBodyv.data.platform || edit.object.platform,
+                        fileSize: mod.fileSize || edit.object.fileSize
                     };
                     edit.save();
                     break;

--- a/src/api/routes/createMod.ts
+++ b/src/api/routes/createMod.ts
@@ -145,6 +145,10 @@ export class CreateModRoutes {
                 return res.status(401).send({ message: `You cannot upload to this mod.` });
             }
 
+            if (mod.status === Status.Removed) {
+                return res.status(401).send({ message: `This mod has been denied and removed` });
+            }
+
             if ((await Validator.validateIDArray(reqBody.data.supportedGameVersionIds, `gameVersions`, false, false)) == false) {
                 return res.status(400).send({ message: `Invalid game version.` });
             }

--- a/src/api/routes/createMod.ts
+++ b/src/api/routes/createMod.ts
@@ -88,7 +88,8 @@ export class CreateModRoutes {
                 // this is fine because we've already validated the icon to be a single file assuming icon
                 iconFileName: iconIsValid ? `${(icon as UploadedFile).md5}${path.extname((icon as UploadedFile).name)}` : `default.png`,
                 lastUpdatedById: session.user.id,
-                status: Status.Private,
+                fileSize: 0,
+                status: Status .Private,
             }).then(async (mod) => {
                 DatabaseHelper.refreshCache(`mods`);
                 if (iconIsValid) {
@@ -157,7 +158,7 @@ export class CreateModRoutes {
                 return res.status(400).send({ message: `Invalid dependency.` });
             }
 
-            if (!file || Array.isArray(file) || file.size > Config.fileUploadLimitMB * 1024 * 1024) {
+            if (!file || Array.isArray(file) || file.size > Config.server.fileUploadLimitMB * 1024 * 1024) {
                 return res.status(413).send({ message: `File missing or too large.` });
             }
             //#endregion
@@ -202,8 +203,12 @@ export class CreateModRoutes {
                 contentHashes: hashs,
                 zipHash: file.md5,
                 lastUpdatedById: session.user.id,
+                fileSize: file.size
             }).then(async (modVersion) => {
+                mod.fileSize = modVersion.fileSize;
+                mod.save()
                 DatabaseHelper.refreshCache(`modVersions`);
+                DatabaseHelper.refreshCache(`mods`);
                 let retVal = await modVersion.toRawAPIResonse();
                 return res.status(200).send({ modVersion: retVal });
             }).catch((error) => {

--- a/src/api/routes/createMod.ts
+++ b/src/api/routes/createMod.ts
@@ -157,7 +157,7 @@ export class CreateModRoutes {
                 return res.status(400).send({ message: `Invalid dependency.` });
             }
 
-            if (!file || Array.isArray(file) || file.size > 75 * 1024 * 1024) {
+            if (!file || Array.isArray(file) || file.size > 150 * 1024 * 1024) {
                 return res.status(413).send({ message: `File missing or too large.` });
             }
             //#endregion

--- a/src/api/routes/createMod.ts
+++ b/src/api/routes/createMod.ts
@@ -157,7 +157,7 @@ export class CreateModRoutes {
                 return res.status(400).send({ message: `Invalid dependency.` });
             }
 
-            if (!file || Array.isArray(file) || file.size > 150 * 1024 * 1024) {
+            if (!file || Array.isArray(file) || file.size > Config.fileUploadLimitMB * 1024 * 1024) {
                 return res.status(413).send({ message: `File missing or too large.` });
             }
             //#endregion

--- a/src/api/routes/updateMod.ts
+++ b/src/api/routes/updateMod.ts
@@ -104,6 +104,7 @@ export class UpdateModRoutes {
                         gitUrl: reqBody.data.gitUrl || mod.gitUrl,
                         authorIds: reqBody.data.authorIds || mod.authorIds,
                         category: reqBody.data.category || mod.category,
+                        fileSize: mod.fileSize
                     }
                 }).then((edit) => {
                     Logger.log(`Edit ${edit.id} (for ${edit.objectId}) submitted by ${session.user.id} for approval.`);
@@ -285,6 +286,7 @@ export class UpdateModRoutes {
                         modVersion: reqBody.data.modVersion ? new SemVer(reqBody.data.modVersion) : modVersion.modVersion,
                         dependencies: reqBody.data.dependencies || modVersion.dependencies,
                         platform: reqBody.data.platform || modVersion.platform,
+                        fileSize: modVersion.fileSize
                     }
                 }).then((edit) => {
                     res.status(200).send({ message: `Edit ${edit.id} (for ${edit.objectId}) submitted by ${session.user.id} for approval.`, edit: edit });

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -107,8 +107,8 @@ export class UserRoutes {
             }
         });
 
-        /*
-        this.app.patch(`/user/:id/`, async (req, res) => {
+        
+        this.router.patch(`/user/:id/`, async (req, res) => {
             // #swagger.tags = ['User']
             // #swagger.summary = 'Get user information.'
             // #swagger.description = 'Get user information.'
@@ -122,18 +122,16 @@ export class UserRoutes {
             if (!session) {
                 return;
             }
-
-            if (!HTTPTools.validateNumberParameter(req.params.id)) {
+            let id = Validator.zDBID.safeParse(req.params.id);
+            if (!id.success) {
                 return res.status(400).send({ error: `Invalid parameters.` });
             }
-            let id = HTTPTools.parseNumberParameter(req.params.id);
-            let user = await editUser(id, displayName, sponsorUrl, bio);
+            let user = await editUser(id.data, displayName, sponsorUrl, bio);
             if (user === `usererror`) {
                 return res.status(400).send({ error: `Invalid parameters.` });
             }
             return res.status(200).send({ user: user.toAPIResponse() });
         });
-        */
 
         this.router.post(`/user/:id/roles/`, async (req, res) => {
             const session = await validateSession(req, res, UserRoles.Admin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ app.use(cors({
 }));
 app.use(fileUpload({
     limits: {
-        fileSize: 75 * 1024 * 1024, // here you go kaitlyn
+        fileSize: Config.fileUploadLimitMB * 1024 * 1024, // here you go kaitlyn
         files: 1
     },
     abortOnLimit: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@ app.use(cors({
     credentials: Config.server.iHateSecurity ? true : false,
 }));
 app.use(fileUpload({
-    limits: {
-        fileSize: Config.server.fileUploadLimitMB * 1024 * 1024, // here you go kaitlyn
+    limits: {            // allow 3x limit for users with LargeFiles role. (File size is checked again later at the limit)
+        fileSize: Config.server.fileUploadLimitMB * 3 * 1024 * 1024, // here you go kaitlyn
         files: 1
     },
     abortOnLimit: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ app.use(cors({
 }));
 app.use(fileUpload({
     limits: {
-        fileSize: Config.fileUploadLimitMB * 1024 * 1024, // here you go kaitlyn
+        fileSize: Config.server.fileUploadLimitMB * 1024 * 1024, // here you go kaitlyn
         files: 1
     },
     abortOnLimit: true,

--- a/src/shared/Config.ts
+++ b/src/shared/Config.ts
@@ -584,8 +584,8 @@ export class Config {
                 failedToLoad.push(`flags.enableDBHealthCheck`);
             }
 
-            if (process.env.FILE_UPLOAD_LIMIT_MB) {
-                Config._fileUloadLimitMB= parseInt(process.env.FILE_UPLOAD_LIMIT_MB);
+            if (process.env.PUBLIC_FILE_UPLOAD_LIMIT_MB) {
+                Config._fileUloadLimitMB= parseInt(process.env.PUBLIC_FILE_UPLOAD_LIMIT_MB);
             } else {
                 failedToLoad.push(`flags.enableDBHealthCheck`);
             }

--- a/src/shared/Config.ts
+++ b/src/shared/Config.ts
@@ -64,7 +64,8 @@ const DEFAULT_CONFIG = {
         enableBanner: false, // enables the banner route /banner.png
         enableSwagger: true, // enables the swagger docs at /api/docs
         enableDBHealthCheck: false, // enables the database health check
-    }
+    },
+    fileUploadLimitMB: 150
 };
 
 
@@ -122,6 +123,7 @@ export class Config {
         enableSwagger: boolean;
         enableDBHealthCheck: boolean;
     };
+    private static _fileUloadLimitMB: number = DEFAULT_CONFIG.fileUploadLimitMB;
     // #endregion
     // #region Public Static Properties
     public static get auth() {
@@ -150,6 +152,9 @@ export class Config {
     }
     public static get flags() {
         return this._flags;
+    }
+    public static get fileUploadLimitMB() {
+        return this._fileUloadLimitMB;
     }
     // #endregion
     constructor() {
@@ -305,6 +310,16 @@ export class Config {
                     }
                 } else {
                     failedToLoad.push(`bot`);
+                }
+
+                if (`fileUploadLimitMB` in cf) {
+                    if (!doObjKeysMatch(cf.fileUploadLimitMB, DEFAULT_CONFIG.fileUploadLimitMB)) {
+                        failedToLoad.push(`fileUploadLimitMB`);
+                    } else {
+                        Config._fileUloadLimitMB = cf.fileUploadLimitMB;
+                    }
+                } else {
+                    failedToLoad.push(`fileUploadLimitMB`);
                 }
                 return failedToLoad;
             } catch (e) {
@@ -565,6 +580,12 @@ export class Config {
 
             if (process.env.FLAGS_ENABLEDBHEALTHCHECK) {
                 Config._flags.enableDBHealthCheck = process.env.FLAGS_ENABLEDBHEALTHCHECK === `true`;
+            } else {
+                failedToLoad.push(`flags.enableDBHealthCheck`);
+            }
+
+            if (process.env.FILE_UPLOAD_LIMIT_MB) {
+                Config._fileUloadLimitMB= parseInt(process.env.FILE_UPLOAD_LIMIT_MB);
             } else {
                 failedToLoad.push(`flags.enableDBHealthCheck`);
             }

--- a/src/shared/Database.ts
+++ b/src/shared/Database.ts
@@ -763,6 +763,7 @@ export enum UserRoles {
     Poster = `poster`,
     Approver = `approver`,
     Moderator = `moderator`,
+    LargeFiles = `largefiles`,
     Banned = `banned`,
 }
 // #endregion

--- a/src/shared/Database.ts
+++ b/src/shared/Database.ts
@@ -320,6 +320,10 @@ export class DatabaseManager {
                 type: DataTypes.INTEGER,
                 allowNull: false,
             },
+            fileSize: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
             createdAt: DataTypes.DATE, // just so that typescript isn't angy
             updatedAt: DataTypes.DATE,
             deletedAt: DataTypes.DATE
@@ -420,6 +424,10 @@ export class DatabaseManager {
                 allowNull: true,
             },
             lastUpdatedById: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+            },
+            fileSize: {
                 type: DataTypes.INTEGER,
                 allowNull: false,
             },
@@ -831,6 +839,7 @@ export class Mod extends Model<InferAttributes<Mod>, InferCreationAttributes<Mod
     declare gitUrl: string;
     declare lastApprovedById: CreationOptional<number> | null;
     declare lastUpdatedById: number;
+    declare fileSize: number;
     declare readonly createdAt: CreationOptional<Date>;
     declare readonly updatedAt: CreationOptional<Date>;
     declare readonly deletedAt: CreationOptional<Date>;
@@ -918,6 +927,7 @@ export class Mod extends Model<InferAttributes<Mod>, InferCreationAttributes<Mod
             gitUrl: this.gitUrl,
             lastApprovedById: this.lastApprovedById,
             lastUpdatedById: this.lastUpdatedById,
+            fileSize: this.fileSize,
             createdAt: this.createdAt,
             updatedAt: this.updatedAt,
         };
@@ -939,6 +949,7 @@ export class ModVersion extends Model<InferAttributes<ModVersion>, InferCreation
     declare downloadCount: CreationOptional<number>;
     declare lastApprovedById: CreationOptional<number> | null;
     declare lastUpdatedById: number;
+    declare fileSize: number;
     declare readonly createdAt: CreationOptional<Date>;
     declare readonly updatedAt: CreationOptional<Date>;
     declare readonly deletedAt: CreationOptional<Date> | null;
@@ -985,6 +996,7 @@ export class ModVersion extends Model<InferAttributes<ModVersion>, InferCreation
                     modVersion: this.modVersion,
                     platform: this.platform,
                     supportedGameVersionIds: [...this.supportedGameVersionIds, gameVersionId],
+                    fileSize: this.fileSize
                 },
             });
         }
@@ -1081,6 +1093,7 @@ export class ModVersion extends Model<InferAttributes<ModVersion>, InferCreation
             contentHashes: this.contentHashes,
             supportedGameVersions: this.supportedGameVersionIds,
             downloadCount: this.downloadCount,
+            fileSize: this.fileSize,
             createdAt: this.createdAt,
             updatedAt: this.updatedAt,
         };
@@ -1115,6 +1128,7 @@ export class ModVersion extends Model<InferAttributes<ModVersion>, InferCreation
             contentHashes: this.contentHashes,
             downloadCount: this.downloadCount,
             supportedGameVersions: await this.getSupportedGameVersions(),
+            fileSize: this.fileSize,
             createdAt: this.createdAt,
             updatedAt: this.updatedAt,
         };
@@ -1298,6 +1312,7 @@ export type ModAPIPublicResponse = {
     gitUrl: string;
     lastApprovedById: number | null;
     lastUpdatedById: number;
+    fileSize: number;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -1313,6 +1328,7 @@ export type ModVersionAPIPublicResponse = {
     dependencies: number[];
     supportedGameVersions: GameVersionAPIPublicResponse[];
     downloadCount: number;
+    fileSize: number;
     createdAt: Date;
     updatedAt: Date;
 }


### PR DESCRIPTION
Increase mod file upload limit from 75mb to 150mb. I'm gonna need a larger upload limit eventually for libcef being over 100mb.
And prevent uploading new mod versions to mods under removed status, as I'm *assuming* once they are removed status, they aren't coming back?