### PR TITLE
Bugfix/disallow uploading to removed mod

### DIFF
--- a/src/api/routes/createMod.ts
+++ b/src/api/routes/createMod.ts
@@ -145,6 +145,10 @@ export class CreateModRoutes {
                 return res.status(401).send({ message: `You cannot upload to this mod.` });
             }
 
+            if (mod.status === Status.Removed) {
+                return res.status(401).send({ message: `This mod has been denied and removed` });
+            }
+
             if ((await Validator.validateIDArray(reqBody.data.supportedGameVersionIds, `gameVersions`, false, false)) == false) {
                 return res.status(400).send({ message: `Invalid game version.` });
             }


### PR DESCRIPTION
A user should not be able to upload to a mod under removed status.
I've split out that PR, gonna start making new ones from the branches for each feature.